### PR TITLE
Makfile and kernel 4.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,4 @@ install: all
 
 clean:
 	rm -rf */*.o */*.ko */*.mod.c */.*.cmd .tmp_versions Module* modules*
-
-
+	$(MAKE) -C apps clean

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -1,4 +1,6 @@
-all: cit citin flashprog modt ddtest setmod ddflash
+APPS = cit citin flashprog modt ddtest setmod ddflash
+
+all: $(APPS)
 
 cit: cit.c
 	gcc -o cit cit.c -lpthread
@@ -17,3 +19,6 @@ ddtest: ddtest.c
 
 ddflash: ddflash.c
 	gcc -o ddflash ddflash.c
+
+clean:
+	rm -rf $(APPS)

--- a/ddbridge/octonet.c
+++ b/ddbridge/octonet.c
@@ -25,7 +25,7 @@
 
 #include "ddbridge.h"
 #include "ddbridge-regs.h"
-#include <asm-generic/pci-dma-compat.h>
+#include <linux/pci-dma-compat.h>
 
 static int adapter_alloc = 3;
 module_param(adapter_alloc, int, 0444);


### PR DESCRIPTION
Added apps dir to the clean Makefile target
and changed a include path for newer kernels (4.6.0)
