### PR TITLE
Syslog getting spammed.

### DIFF
--- a/frontends/mxl5xx.c
+++ b/frontends/mxl5xx.c
@@ -671,10 +671,10 @@ static int read_ber(struct dvb_frontend *fe, u32 *ber)
 	default:
 		break;
 	}
-	pr_info("mxl5xx: ber %08x %08x %08x %08x %08x %08x %08x\n",
-		reg[0], reg[1], reg[2], reg[3], reg[4], reg[5], reg[6]);
-	pr_info("mxl5xx: ber2 %08x %08x %08x %08x\n",
-		reg[0], reg[1], reg[2], reg[3]);
+	//pr_info("mxl5xx: ber %08x %08x %08x %08x %08x %08x %08x\n",
+	//	reg[0], reg[1], reg[2], reg[3], reg[4], reg[5], reg[6]);
+	//pr_info("mxl5xx: ber2 %08x %08x %08x %08x\n",
+	//	reg[0], reg[1], reg[2], reg[3]);
         //pre_bit_error, pre_bit_count
 	//post_bit_error, post_bit_count;
 	//block_error block_count;
@@ -756,9 +756,9 @@ static int get_frontend(struct dvb_frontend *fe)
 	HYDRA_DEMOD_STATUS_UNLOCK(state, state->demod);
 	mutex_unlock(&state->base->status_lock);
 	
-	pr_info("mxl5xx: freq=%u delsys=%u srate=%u\n",
-		freq * 1000, regData[DMD_STANDARD_ADDR],
-		regData[DMD_SYMBOL_RATE_ADDR]);
+	//pr_info("mxl5xx: freq=%u delsys=%u srate=%u\n",
+	//	freq * 1000, regData[DMD_STANDARD_ADDR],
+	//	regData[DMD_SYMBOL_RATE_ADDR]);
 	p->symbol_rate = regData[DMD_SYMBOL_RATE_ADDR];
 	p->frequency = freq;
 	//p->delivery_system = (MXL_HYDRA_BCAST_STD_E )regData[DMD_STANDARD_ADDR];

--- a/frontends/mxl5xx.c
+++ b/frontends/mxl5xx.c
@@ -521,7 +521,6 @@ static int set_parameters(struct dvb_frontend *fe)
 		while (time_before(jiffies, state->base->next_tune))
 			msleep(10);
 	state->base->next_tune = jiffies + msecs_to_jiffies(100);
-	/* pr_info("mxl5xx tune\n"); */
 	state->tuner_in_use = state->tuner;
 	BUILD_HYDRA_CMD(MXL_HYDRA_DEMOD_SET_PARAM_CMD, MXL_CMD_WRITE,
 			cmdSize, &demodChanCfg, cmdBuff);

--- a/frontends/mxl5xx.c
+++ b/frontends/mxl5xx.c
@@ -521,6 +521,7 @@ static int set_parameters(struct dvb_frontend *fe)
 		while (time_before(jiffies, state->base->next_tune))
 			msleep(10);
 	state->base->next_tune = jiffies + msecs_to_jiffies(100);
+	/* pr_info("mxl5xx tune\n"); */
 	state->tuner_in_use = state->tuner;
 	BUILD_HYDRA_CMD(MXL_HYDRA_DEMOD_SET_PARAM_CMD, MXL_CMD_WRITE,
 			cmdSize, &demodChanCfg, cmdBuff);


### PR DESCRIPTION
Issue reported [here.](http://lime-technology.com/forum/index.php?topic=47899.msg482760#msg482760) and [here](http://www.vdr-portal.de/board18-vdr-hardware/board102-dvb-karten/p1272020-aktuelle-treiber-f%C3%BCr-octopus-ddbridge-cines2-ngene-ddbridge-duoflex-s2-duoflex-ct-cinect-max-s8-sowie-tt-s2-6400-teil-3/#post1272020) with 3PO providing a [.diff](http://www.vdr-portal.de/board18-vdr-hardware/board102-dvb-karten/p1272026-aktuelle-treiber-f%C3%BCr-octopus-ddbridge-cines2-ngene-ddbridge-duoflex-s2-duoflex-ct-cinect-max-s8-sowie-tt-s2-6400-teil-3/#post1272026) (Only changes to mxl5xx.c are relevant now)
