### PR TITLE
stv0910: Fix possible buffer overflow, fix nBCH table offset

### DIFF
--- a/frontends/stv0910.c
+++ b/frontends/stv0910.c
@@ -673,6 +673,7 @@ static int GetBitErrorRateS(struct stv *state, u32 *BERNumerator,
 static u32 DVBS2_nBCH(enum DVBS2_ModCod ModCod, enum DVBS2_FECType FECType)
 {
 	static u32 nBCH[][2] = {
+		{    0,     0}, /* DUMMY_PLF */
 		{16200,  3240}, /* QPSK_1_4, */
 		{21600,  5400}, /* QPSK_1_3, */
 		{25920,  6480}, /* QPSK_2_5, */
@@ -705,7 +706,7 @@ static u32 DVBS2_nBCH(enum DVBS2_ModCod ModCod, enum DVBS2_FECType FECType)
 
 	if (ModCod >= DVBS2_QPSK_1_4 &&
 	    ModCod <= DVBS2_32APSK_9_10 && FECType <= DVBS2_16K)
-		return nBCH[FECType][ModCod];
+		return nBCH[ModCod][FECType];
 	return 64800;
 }
 


### PR DESCRIPTION
During preparation of mainlining the stv0910 driver, smatch discovered:

    drivers/media/dvb-frontends/stv0910.c:715 DVBS2_nBCH() error: buffer overflow 'nBCH[FECType]' 2 <= 28

Fix this by correcting the array access (ModCod.FECType vs. FECType.ModCod) in the return. Also add a dummy value ontop of the table to have the array index offset fixed.