### PR TITLE
octonet: add __refdata annotation to "struct platform_driver octonet_driver {...}"

### DIFF
--- a/ddbridge/octonet.c
+++ b/ddbridge/octonet.c
@@ -217,7 +217,7 @@ static const struct of_device_id octonet_dt_ids[] = {
 MODULE_DEVICE_TABLE(of, octonet_dt_ids);
 #endif
 
-static struct platform_driver octonet_driver = {
+static struct platform_driver __refdata octonet_driver = {
 	.remove	= __exit_p(octonet_remove),
 	.probe	= octonet_probe,
 	.driver		= {


### PR DESCRIPTION
fixes section mismatch warning during compile

  $ make CONFIG_DEBUG_SECTION_MISMATCH=y -j3
  [...]
    MODPOST 16 modules
  WARNING: ddbridge/octonet.o(.data+0x0): Section mismatch in reference from the variable octonet_driver to the function
  .init.text:octonet_probe()
  The variable octonet_driver references
  the function __init octonet_probe()
  If the reference is valid then annotate the
  variable with __init* or __refdata (see linux/init.h) or name the variable:
  *_template, *_timer, *_sht, *_ops, *_probe, *_probe_one, *_console