### PR TITLE
fix SYS_DVBC2 in dvbv3_type()

### DIFF
--- a/dvb-core/dvb_frontend.c
+++ b/dvb-core/dvb_frontend.c
@@ -178,6 +178,7 @@ static enum dvbv3_emulation_type dvbv3_type(u32 delivery_system)
 	case SYS_DVBT2:
 	case SYS_ISDBT:
 	case SYS_DTMB:
+	case SYS_DVBC2:
 		return DVBV3_OFDM;
 	case SYS_ATSC:
 	case SYS_ATSCMH:


### PR DESCRIPTION
add SYS_DVBC2 case in dvbv3_type() function to return correct DVBV3_OFDM result instead of DVBV3_UNKNOWN. now driver locks correct to DVB-C2 modulator.