### PR TITLE
stv0910: Support a minimum symbol rate of 100KSyms/s

### DIFF
--- a/frontends/stv0910.c
+++ b/frontends/stv0910.c
@@ -1776,7 +1776,7 @@ static struct dvb_frontend_ops stv0910_ops = {
 		.frequency_max		= 2150000,
 		.frequency_stepsize	= 0,
 		.frequency_tolerance	= 0,
-		.symbol_rate_min	= 1000000,
+		.symbol_rate_min	= 100000,
 		.symbol_rate_max	= 70000000,
 		.caps			= FE_CAN_INVERSION_AUTO |
 					  FE_CAN_FEC_AUTO       |


### PR DESCRIPTION
The logic in Start() supports and handles such low symbol rates and this
has even been tested working in a card review carrying this demod IC (see
[1]), so announce this accordingly in the frontend_ops.

[1] http://rfsync.blogspot.de/2016/04/tbs6903-review-best-dvb-s2-tuner-for.html

@rjkm @mvoelkel 