### PR TITLE
Fix compile   4.4.0-104-generic

### DIFF
--- a/ddbridge/Kbuild
+++ b/ddbridge/Kbuild
@@ -9,3 +9,5 @@ obj-$(CONFIG_DVB_OCTONET) += octonet.o
 EXTRA_CFLAGS += -Idrivers/media/dvb/frontends -Idrivers/media/dvb-frontends
 EXTRA_CFLAGS += -Idrivers/media/common/tuners
 NOSTDINC_FLAGS += -I$(SUBDIRS)/frontends -I$(SUBDIRS)/include -I$(SUBDIRS)/dvb-core
+EXTRA_CFLAGS += -Wno-error=implicit-function-declaration
+

--- a/ddbridge/ddbridge-main.c
+++ b/ddbridge/ddbridge-main.c
@@ -25,6 +25,7 @@
 #include "ddbridge-io.h"
 
 #ifdef CONFIG_PCI_MSI
+#include <linux/msi.h>
 static int msi = 1;
 module_param(msi, int, 0444);
 MODULE_PARM_DESC(msi,


### PR DESCRIPTION
Ubuntu 16.04.3 LTS

ddbridge-main.c:41:38: error: expected ‘;’ before ‘{’ token
   for_each_pci_msi_entry(entry, dev) {

ddbridge-main.c:52:31: error: dereferencing pointer to incomplete type ‘struct msi_desc’
   if (WARN_ON_ONCE(nr >= entry->nvec_used))