### PR TITLE
Fix - regular upcoming fragments

### DIFF
--- a/ddbridge/ddbridge-mci.c
+++ b/ddbridge/ddbridge-mci.c
@@ -91,11 +91,9 @@ static int ddb_mci_cmd_raw_unlocked(struct mci *state,
 			printk("Lost PCIe link!\n");
 			return -EIO;
 		} else {
-			printk("DDBridge IRS %08x link %u\n", istat, link->nr);
+            printk("DDBridge IRS %08x\n", istat)
 			if (istat & 1) 
-				ddblwritel(link, istat, INTERRUPT_ACK);
-			if (link->nr)
-				ddbwritel(link->dev, 0xffffff, INTERRUPT_ACK);
+				ddblwritel(link, istat & 1, INTERRUPT_ACK);
 		}
 	}
 	if (res && res_len)


### PR DESCRIPTION
removed lines where included with https://github.com/DigitalDevices/dddvb/commit/154ea8f3c9eda5acf35ed76435520f78fecffe39
and causes regular (every 1-2 minutes) upcoming fragments on Videostream.

Issue can be seen very good on h264 encoded High Definition TV Channels.