### PR TITLE
fix(app): Remove setmod1 from Makefile

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -1,4 +1,4 @@
-TARGETS = cit ddtest setmod1 setmod2 modconfig ddinfo getiq modtest
+TARGETS = cit ddtest setmod2 modconfig ddinfo getiq modtest
 
 all: $(TARGETS) 
 


### PR DESCRIPTION
c0e174505a59a5bf644939b4f391cf225a7acb01 removed several old apps, but did also add 'setmod1'. Either that was by accident or you forgot to add and commit its source code.

Compilation currently fails:
> make: *** No rule to make target 'setmod1', needed by 'all'.  Stop.