### PR TITLE
libdddvb: install dvb_filter.h

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -6,6 +6,7 @@ install: all
 	cp -d src/libdddvb.so* /usr/local/lib
 	cp -d src/libdddvb.h /usr/local/include/
 	cp -d src/dddvb.h /usr/local/include/
+	cp -d src/dvb_filter.h /usr/local/include/
 	cp -d ddzap /usr/local/bin
 	ldconfig
 


### PR DESCRIPTION
With the most recent commits dvb_filter.h was added but not installed by the Makefile